### PR TITLE
feat: add .cursor to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ mock/
 
 # IDEs
 .idea
+.cursor
 
 # Builds
 bin/


### PR DESCRIPTION
Add .cursor directory to .gitignore to exclude Cursor IDE configuration files from version control.