### PR TITLE
feat: add configuration setting to control cost widget visibility

### DIFF
--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1421,6 +1421,11 @@ export class ClineProvider
 		const mergedAllowedCommands = this.mergeAllowedCommands(allowedCommands)
 		const cwd = this.cwd
 
+		// Read VSCode configuration settings
+		const showCostWidget = vscode.workspace
+			.getConfiguration(Package.name)
+			.get<boolean>("roo.tasks.showCostWidget", true)
+
 		// Check if there's a system prompt override for the current mode
 		const currentMode = mode ?? defaultModeSlug
 		const hasSystemPromptOverride = await this.hasFileBasedSystemPromptOverride(currentMode)
@@ -1526,6 +1531,7 @@ export class ClineProvider
 			hasOpenedModeSelector: this.getGlobalState("hasOpenedModeSelector") ?? false,
 			alwaysAllowFollowupQuestions: alwaysAllowFollowupQuestions ?? false,
 			followupAutoApproveTimeoutMs: followupAutoApproveTimeoutMs ?? 60000,
+			showCostWidget,
 		}
 	}
 

--- a/src/core/webview/ClineProvider.ts
+++ b/src/core/webview/ClineProvider.ts
@@ -1422,9 +1422,7 @@ export class ClineProvider
 		const cwd = this.cwd
 
 		// Read VSCode configuration settings
-		const showCostWidget = vscode.workspace
-			.getConfiguration(Package.name)
-			.get<boolean>("roo.tasks.showCostWidget", true)
+		const showCostWidget = vscode.workspace.getConfiguration(Package.name).get<boolean>("showCostWidget", true)
 
 		// Check if there's a system prompt override for the current mode
 		const currentMode = mode ?? defaultModeSlug

--- a/src/package.json
+++ b/src/package.json
@@ -3,7 +3,7 @@
 	"displayName": "%extension.displayName%",
 	"description": "%extension.description%",
 	"publisher": "IdenWorks",
-	"version": "3.23.7",
+	"version": "3.23.8",
 	"icon": "assets/icons/icon.png",
 	"galleryBanner": {
 		"color": "#617A91",

--- a/src/package.json
+++ b/src/package.json
@@ -353,6 +353,11 @@
 					"type": "string",
 					"default": "",
 					"description": "%settings.autoImportSettingsPath.description%"
+				},
+				"roo.tasks.showCostWidget": {
+					"type": "boolean",
+					"default": true,
+					"description": "Show/hide the cost widget in the task page header."
 				}
 			}
 		}

--- a/src/package.json
+++ b/src/package.json
@@ -354,7 +354,7 @@
 					"default": "",
 					"description": "%settings.autoImportSettingsPath.description%"
 				},
-				"roo.tasks.showCostWidget": {
+				"roo-otto.showCostWidget": {
 					"type": "boolean",
 					"default": true,
 					"description": "Show/hide the cost widget in the task page header."

--- a/webview-ui/src/components/chat/TaskHeader.tsx
+++ b/webview-ui/src/components/chat/TaskHeader.tsx
@@ -50,7 +50,7 @@ const TaskHeader = ({
 	todos,
 }: TaskHeaderProps) => {
 	const { t } = useTranslation()
-	const { apiConfiguration, currentTaskItem } = useExtensionState()
+	const { apiConfiguration, currentTaskItem, showCostWidget } = useExtensionState()
 	const { id: modelId, info: model } = useSelectedModel(apiConfiguration)
 	const [isTaskExpanded, setIsTaskExpanded] = useState(false)
 
@@ -122,7 +122,7 @@ const TaskHeader = ({
 						/>
 						{condenseButton}
 						<ShareButton item={currentTaskItem} disabled={buttonsDisabled} />
-						{!!totalCost && <VSCodeBadge>${totalCost.toFixed(2)}</VSCodeBadge>}
+						{showCostWidget && !!totalCost && <VSCodeBadge>${totalCost.toFixed(2)}</VSCodeBadge>}
 					</div>
 				)}
 				{/* Expanded state: Show task text and images */}
@@ -185,7 +185,9 @@ const TaskHeader = ({
 										</span>
 									)}
 								</div>
-								{!totalCost && <TaskActions item={currentTaskItem} buttonsDisabled={buttonsDisabled} />}
+								{(!showCostWidget || !totalCost) && (
+									<TaskActions item={currentTaskItem} buttonsDisabled={buttonsDisabled} />
+								)}
 							</div>
 
 							{((typeof cacheReads === "number" && cacheReads > 0) ||
@@ -207,7 +209,7 @@ const TaskHeader = ({
 								</div>
 							)}
 
-							{!!totalCost && (
+							{showCostWidget && !!totalCost && (
 								<div className="flex justify-between items-center h-[20px]">
 									<div className="flex items-center gap-1">
 										<span className="font-bold">{t("chat:task.apiCost")}</span>

--- a/webview-ui/src/components/chat/__tests__/TaskHeader.spec.tsx
+++ b/webview-ui/src/components/chat/__tests__/TaskHeader.spec.tsx
@@ -4,8 +4,6 @@ import React from "react"
 import { render, screen, fireEvent } from "@/utils/test-utils"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
 
-import type { ProviderSettings } from "@roo-code/types"
-
 import TaskHeader, { TaskHeaderProps } from "../TaskHeader"
 
 // Mock i18n
@@ -34,14 +32,15 @@ vi.mock("@vscode/webview-ui-toolkit/react", () => ({
 
 // Mock the ExtensionStateContext
 vi.mock("@src/context/ExtensionStateContext", () => ({
-	useExtensionState: () => ({
+	useExtensionState: vi.fn(() => ({
 		apiConfiguration: {
 			apiProvider: "anthropic",
-			apiKey: "test-api-key", // Add relevant fields
-			apiModelId: "claude-3-opus-20240229", // Add relevant fields
-		} as ProviderSettings, // Optional: Add type assertion if ProviderSettings is imported
+			apiKey: "test-api-key",
+			apiModelId: "claude-3-opus-20240229",
+		},
 		currentTaskItem: { id: "test-task-id" },
-	}),
+		showCostWidget: true,
+	})),
 }))
 
 describe("TaskHeader", () => {
@@ -66,7 +65,7 @@ describe("TaskHeader", () => {
 		)
 	}
 
-	it("should display cost when totalCost is greater than 0", () => {
+	it("should display cost when totalCost is greater than 0 and showCostWidget is true", () => {
 		renderTaskHeader()
 		expect(screen.getByText("$0.05")).toBeInTheDocument()
 	})

--- a/webview-ui/src/context/ExtensionStateContext.tsx
+++ b/webview-ui/src/context/ExtensionStateContext.tsx
@@ -131,6 +131,7 @@ export interface ExtensionStateContextType extends ExtensionState {
 	routerModels?: RouterModels
 	alwaysAllowUpdateTodoList?: boolean
 	setAlwaysAllowUpdateTodoList: (value: boolean) => void
+	showCostWidget?: boolean
 }
 
 export const ExtensionStateContext = createContext<ExtensionStateContextType | undefined>(undefined)


### PR DESCRIPTION
## Summary

This PR adds a new VSCode configuration setting `roo.tasks.showCostWidget` that allows users to control the visibility of the cost widget in the task page header.

## Changes

- **package.json**: Added new boolean configuration property `roo.tasks.showCostWidget` with default value `true`
- **ClineProvider.ts**: Updated `getStateToPostToWebview()` method to read the VSCode configuration setting and include it in the webview state
- **TaskHeader.tsx**: Modified component to conditionally render cost widget based on the `showCostWidget` setting from extension state
- **ExtensionStateContext.tsx**: Added `showCostWidget` property to the context interface

## Behavior

- **Default**: Cost widget is shown (maintains existing behavior)
- **When disabled**: Cost widget is hidden in both collapsed and expanded task header states
- **Setting location**: VSCode Settings → Extensions → Roo → Tasks → Show Cost Widget

## Testing

- All existing tests pass
- Build and type checking successful
- Linting passes

This enhancement provides users with the flexibility to hide cost information if they prefer a cleaner interface while maintaining backward compatibility.